### PR TITLE
Introduce environment field metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,13 @@ And something like this would render an input that would update the underlying v
 
 ## Usage
 
-The entry point to a UI powered by ember-exclaim is the `{{exclaim-ui}}` component. It expects three arguments:
+The entry point to a UI powered by ember-exclaim is the `{{exclaim-ui}}` component. It expects up to four arguments:
  - `ui`: an object containing configuration for the UI that should be rendered
  - `env`: a hash whose keys will be bindable from the `ui` config, to be read from and written to
  - `componentMap`: a mapping of component names in the `ui` config to information about their backing Ember components
+ - `resolveMeta(path)`: an optional action that will be invoked if a component calls `env.metaFor(...)`
 
-Each of these three things is described in further detail below.
+Each of these things is described in further detail below.
 
 ### UI Configuration
 
@@ -124,6 +125,14 @@ The `componentMap` given to `{{exclaim-ui}}` dictates what components it can ren
  - `componentPath`: the name to the Ember component to be invoked when this exclaim-ui component is used in the config, as you'd give it to the `{{component}}` helper
  - `shorthandProperty` (optional): the name of a property that should be populated when shorthand notation is used for this component (see above)
 
+### Metadata Resolution
+
+The `env` property exposed to ember-exclaim components (see below for details) includes a `metaFor(object, key)` method that component implementations can use to discover more information about their bound values. For instance, an `$input` component might call `metaFor(this, 'config.value')` to discover validation rules for its bound value in order to display an error message to the user.
+
+The `resolveMeta` action on `{{exclaim-ui}}` designates how this metadata is discovered. It receives the full path in the environment of the value in question.
+
+This action should return any relevant information available about the field at `valuePath`. Note that, if a component calls `metaFor` on a path that doesn't resolve to a field on the environment, the `resolveMeta` action will not be invoked.
+
 ## Implementing Components
 
 The [demo app](https://salsify.github.io/ember-exclaim) for this repo contains [a variety of simple component implementations](tests/dummy/app/components/exclaim-components) that you can use as a starting point for building your own.
@@ -142,7 +151,9 @@ When invoked as `{ "$component": "input", "value": {"$bind":"x"} }` with `x` in 
 
 ### `env`
 
-The `env` property will contain an object representing the environment that the component is being rendered in. This object has a method `extend`, which, given a hash, can be used to produce a new environment based on the original that contains the values from that hash.
+The `env` property will contain an object representing the environment that the component is being rendered in. This object has two methods:
+ - `extend(hash)`: can be used to produce a new environment based on the original that additionally contains the values from the given hash
+ - `metaFor(object, key)`: takes an object and key, resolves the canonical path for that key in the environment, and then retrieves metadata for that path according to any configured `resolveMeta` action on the owning `{{exclaim-ui}}` component
 
 ### Rendering Children
 

--- a/addon/-private/environment/array.js
+++ b/addon/-private/environment/array.js
@@ -13,10 +13,11 @@ const {
  * paths in the given environment.
  */
 export default class EnvironmentArray extends ArrayProxy {
-  constructor(data, env) {
+  constructor(data, env, key) {
     super({ content: data });
     this.__wrapped__ = (data instanceof EnvironmentArray) ? data.__wrapped__ : A(data);
     this.__env__ = env;
+    this.__key__ = key;
   }
 
   objectAtContent(index) {
@@ -24,7 +25,7 @@ export default class EnvironmentArray extends ArrayProxy {
     if (item instanceof Binding) {
       return get(this.__env__, item.path.join('.'));
     } else {
-      return wrap(item, this.__env__);
+      return wrap(item, this.__env__, this.__key__ && `${this.__key__}.${index}`);
     }
   }
 

--- a/addon/-private/environment/create-env-computed.js
+++ b/addon/-private/environment/create-env-computed.js
@@ -22,8 +22,8 @@ const {
  * Environment instances are their own binding resolution source, so they have no envRoot.)
  */
 export default function createComputed(host, key, valueRoot, envRoot) {
-  const fullKey = `${valueRoot}.${key}`;
-  const result = get(host, fullKey);
+  const fullHostKey = `${valueRoot}.${key}`;
+  const result = get(host, fullHostKey);
   const env = envRoot ? get(host, envRoot) : host;
 
   if (result instanceof Binding) {
@@ -31,13 +31,14 @@ export default function createComputed(host, key, valueRoot, envRoot) {
     host[key] = computed.alias(envPath(envRoot, result));
   } else {
     // Otherwise, we depend on the value of that key on the host object
+    const fullEnvKey = host.__key__ ? `${host.__key__}.${key}` : key;
     host[key] = computed(...determineDependentKeys(result, key, valueRoot, envRoot), {
       get() {
-        return wrap(get(host, fullKey), env);
+        return wrap(get(host, fullHostKey), env, fullEnvKey);
       },
       set(key, value) {
-        set(host, fullKey, value);
-        return wrap(get(host, fullKey), env);
+        set(host, fullHostKey, value);
+        return wrap(get(host, fullHostKey), env, fullEnvKey);
       }
     });
   }

--- a/addon/-private/environment/data.js
+++ b/addon/-private/environment/data.js
@@ -11,10 +11,11 @@ const {
  * paths in the given environment.
  */
 export default class EnvironmentData extends EmberObject {
-  constructor(data, env) {
+  constructor(data, env, key) {
     super();
     this.__wrapped__ = (data instanceof EnvironmentData) ? data.__wrapped__ : data;
     this.__env__ = env;
+    this.__key__ = key;
   }
 
   unknownProperty(key) {

--- a/addon/components/exclaim-ui/component.js
+++ b/addon/components/exclaim-ui/component.js
@@ -18,8 +18,10 @@ export default Component.extend({
 
   componentMap: null,
 
-  baseEnv: computed('env', function() {
-    return new Environment(get(this, 'env') || {});
+  resolveMeta: () => {},
+
+  baseEnv: computed('env', 'resolveMeta', function() {
+    return new Environment(get(this, 'env') || {}, this.get('resolveMeta'));
   }),
 
   content: computed('specProcessor', 'ui', function() {


### PR DESCRIPTION
This PR introduces a notion of metadata on fields in the exclaim environment.

The `{{exclaim-ui}}` component now accepts a `resolveMeta(path)` action, which will receive the full path of the field in question in the given `env` and be expected to return some arbitrary meta information in response, if applicable.

Component implementations now have access to a `metaFor(object, key)` method on their given `env` that they can use to resolve metadata for a given field. For example, an `$input` component might call `env.metaFor(this, 'config.value')` to determine validation rules for the field it's bound to.

@deverstalmage 