### PR TITLE
[RICH-257] collapse empty components

### DIFF
--- a/addon/components/exclaim-component/template.hbs
+++ b/addon/components/exclaim-component/template.hbs
@@ -1,23 +1,11 @@
-{{#component
-  wrapper
-  collapseEmpty=(or collapseEmpty false)
+{{#component wrapper
   componentSpec=unwrappedSpec
   config=resolvedConfig
-  env=effectiveEnv
-  mode=mode}}
-  {{#component
-    componentSpec.path
-    collapseEmpty=collapseEmpty
+  env=effectiveEnv}}
+  {{#component componentSpec.path
     config=resolvedConfig
     env=effectiveEnv
-    mode=mode
     as |componentSpec overrideEnv|}}
-    {{~exclaim-component
-      collapseEmpty=collapseEmpty
-      componentSpec=componentSpec
-      env=effectiveEnv
-      mode=mode
-      overrideEnv=overrideEnv
-      wrapper=wrapper~}}
+    {{~exclaim-component componentSpec=componentSpec env=effectiveEnv overrideEnv=overrideEnv wrapper=wrapper~}}
   {{/component}}
 {{/component}}

--- a/addon/components/exclaim-component/template.hbs
+++ b/addon/components/exclaim-component/template.hbs
@@ -1,13 +1,23 @@
-{{#component wrapper
+{{#component
+  wrapper
+  collapseEmpty=(or collapseEmpty false)
   componentSpec=unwrappedSpec
-  env=effectiveEnv
   config=resolvedConfig
-}}
-  {{#component componentSpec.path
+  env=effectiveEnv
+  mode=mode}}
+  {{#component
+    componentSpec.path
+    collapseEmpty=collapseEmpty
     config=resolvedConfig
     env=effectiveEnv
-    as |componentSpec overrideEnv|
-  }}
-    {{~exclaim-component componentSpec=componentSpec env=effectiveEnv overrideEnv=overrideEnv wrapper=wrapper~}}
+    mode=mode
+    as |componentSpec overrideEnv|}}
+    {{~exclaim-component
+      collapseEmpty=collapseEmpty
+      componentSpec=componentSpec
+      env=effectiveEnv
+      mode=mode
+      overrideEnv=overrideEnv
+      wrapper=wrapper~}}
   {{/component}}
 {{/component}}

--- a/addon/components/exclaim-ui/template.hbs
+++ b/addon/components/exclaim-ui/template.hbs
@@ -1,10 +1,5 @@
 {{#if content.componentSpec}}
-  {{~exclaim-component
-    collapseEmpty=collapseEmpty
-    componentSpec=content.componentSpec
-    env=baseEnv
-    mode=mode
-    wrapper=(or wrapper "exclaim-default-component-wrapper")~}}
+  {{~exclaim-component componentSpec=content.componentSpec env=baseEnv wrapper=(or wrapper 'exclaim-default-component-wrapper')~}}
 {{else if content.error}}
   {{~yield content.error~}}
 {{/if}}

--- a/addon/components/exclaim-ui/template.hbs
+++ b/addon/components/exclaim-ui/template.hbs
@@ -1,5 +1,10 @@
 {{#if content.componentSpec}}
-  {{~exclaim-component componentSpec=content.componentSpec env=baseEnv wrapper=(or wrapper 'exclaim-default-component-wrapper')~}}
+  {{~exclaim-component
+    collapseEmpty=collapseEmpty
+    componentSpec=content.componentSpec
+    env=baseEnv
+    mode=mode
+    wrapper=(or wrapper "exclaim-default-component-wrapper")~}}
 {{else if content.error}}
   {{~yield content.error~}}
 {{/if}}


### PR DESCRIPTION
* [x] pass `mode` attribute down to child components
* [x] pass `collapseEmpty` attr down to children, this allows consumers
to opt-in to empty-component collapsing behavior.

This needs to merge together with other PRs for:
* [x] [enhanced-content-engine #96](https://github.com/salsify/enhanced-content-engine/pull/96)
* [x] [ui-exclaim-base-components #27](https://github.com/salsify/ui-exclaim-base-components/pull/27)
* [x] ember-exclaim-editor https://github.com/salsify/ember-exclaim-editor/pull/14