### PR TITLE
Provide a sensible default noOp function

### DIFF
--- a/addon/-private/environment/index.js
+++ b/addon/-private/environment/index.js
@@ -18,7 +18,9 @@ export default class Environment extends EmberObject.extend(Evented) {
   constructor(bound, metaForField) {
     super();
     this.__bound__ = makeArray(bound);
-    this.__resolveFieldMeta__ = metaForField;
+    this.__resolveFieldMeta__ = typeof metaForField === 'function' ?
+      metaForField :
+      () => {};
   }
 
   extend(values) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-exclaim",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "An addon allowing apps to expose declarative, JSON-configurable custom UIs backed by Ember components",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Fixes a problem where consumers passing `undefined` to `resolveFieldMeta` would be invoked, causing an error.