### PR TITLE
Ensure nested helpers recalculate properly

### DIFF
--- a/addon/-private/helper-spec.js
+++ b/addon/-private/helper-spec.js
@@ -27,6 +27,8 @@ function discoverBindings(config) {
     });
   } else if (config instanceof Binding) {
     bindings.push(config);
+  } else if (config instanceof HelperSpec) {
+    bindings.push(...config.bindings);
   }
   return bindings;
 }

--- a/tests/unit/environment-test.js
+++ b/tests/unit/environment-test.js
@@ -239,16 +239,23 @@ test('helper invocation', function(assert) {
       1,
       2,
       new HelperSpec(config => get(config, 'word.length'), { word: new Binding('shouty') }),
-    ]
+    ],
+    nested: new HelperSpec(config => get(config, 'word').toUpperCase(), {
+      word: new HelperSpec(config => get(config, 'word').split('').reverse().join(''), {
+        word: new Binding('foo')
+      })
+    })
   });
 
   assert.equal(get(env, 'foo'), 'bar');
   assert.equal(get(env, 'shouty'), 'BAR');
+  assert.equal(get(env, 'nested'), 'RAB');
   assert.deepEqual(get(env, 'array').toArray(), [1, 2, 3]);
 
   set(env, 'foo', 'ok');
 
   assert.equal(get(env, 'foo'), 'ok');
   assert.equal(get(env, 'shouty'), 'OK');
+  assert.equal(get(env, 'nested'), 'KO');
   assert.deepEqual(get(env, 'array').toArray(), [1, 2, 2]);
 });


### PR DESCRIPTION
Previously, something like `{ $join: ['Hello, ', { $upcase: { $bind: 'target' } }] }` wouldn't recalculate if the `target` binding did.

/cc @rlburkes 