### PR TITLE
Allow setting and getting array indices in an Environment

### DIFF
--- a/addon/-private/environment/array.js
+++ b/addon/-private/environment/array.js
@@ -25,8 +25,7 @@ export default class EnvironmentArray extends ArrayProxy {
       defineIndexProperty(this, key);
       return get(this, key);
     } else {
-      defineProperty(this, key);
-      return this[key];
+      return this[key] = undefined;
     }
   }
 

--- a/addon/-private/environment/array.js
+++ b/addon/-private/environment/array.js
@@ -5,6 +5,7 @@ import Binding from 'ember-exclaim/-private/binding';
 import HelperSpec from 'ember-exclaim/-private/helper-spec';
 import { wrap } from './index';
 import { extractKey } from './utils';
+import createEnvComputed from './create-env-computed';
 
 /*
  * Wraps an array, resolving any Bindings in it when requested to the corresponding
@@ -49,6 +50,17 @@ export default class EnvironmentArray extends ArrayProxy {
     } else if (items.length > amount) {
       this.__wrapped__.replace(index + items.length, 0, items.slice(amount));
     }
+  }
+
+  unknownProperty(key) {
+    createEnvComputed(this, key, '__wrapped__', '__env__');
+    return get(this, key);
+  }
+
+  setUnknownProperty(key, value) {
+    createEnvComputed(this, key, '__wrapped__', '__env__');
+    set(this, key, value);
+    return get(this, key);
   }
 
   toString() {

--- a/addon/-private/environment/create-env-computed.js
+++ b/addon/-private/environment/create-env-computed.js
@@ -42,7 +42,8 @@ export default function createComputed(host, key, valueRoot, envRoot) {
     // Otherwise, we depend on the value of that key on the host object
     const hostKey = extractKey(host);
     const fullEnvKey = hostKey ? `${hostKey}.${key}` : key;
-    defineProperty(host, key, computed(...determineDependentKeys(result, key, valueRoot, envRoot), {
+    const depKeys = determineDependentKeys(result, key, valueRoot, envRoot);
+    defineProperty(host, key, computed(...depKeys, {
       get() {
         return wrap(get(host, fullHostKey), env, fullEnvKey);
       },

--- a/addon/-private/environment/create-env-computed.js
+++ b/addon/-private/environment/create-env-computed.js
@@ -42,8 +42,7 @@ export default function createComputed(host, key, valueRoot, envRoot) {
     // Otherwise, we depend on the value of that key on the host object
     const hostKey = extractKey(host);
     const fullEnvKey = hostKey ? `${hostKey}.${key}` : key;
-    const depKeys = determineDependentKeys(result, key, valueRoot, envRoot);
-    defineProperty(host, key, computed(...depKeys, {
+    defineProperty(host, key, computed(...determineDependentKeys(result, key, valueRoot, envRoot), {
       get() {
         return wrap(get(host, fullHostKey), env, fullEnvKey);
       },

--- a/tests/unit/environment-test.js
+++ b/tests/unit/environment-test.js
@@ -14,6 +14,18 @@ module('Unit | environment', function() {
     assert.equal(get(env, 'foo'), 'baz');
   });
 
+  test('simple array lookups', function(assert) {
+    const env = new Environment({ foo: ['bar', 'baz'] });
+    assert.equal(get(env, 'foo.0'), 'bar');
+    assert.equal(get(env, 'foo.1'), 'baz');
+  });
+
+  test('set unknown property', function(assert) {
+    const env = new Environment({ foo: ['bar'] });
+    set(env, '3', 'kylerules');
+    assert.equal(get(env, 'foo.3'), 'kylerules');
+  });
+
   test('HTML-safe strings', function(assert) {
     const env = new Environment({ foo: htmlSafe('hello') });
     assert.deepEqual(get(env, 'foo'), htmlSafe('hello'));

--- a/tests/unit/environment-test.js
+++ b/tests/unit/environment-test.js
@@ -31,12 +31,13 @@ module('Unit | environment', function() {
   });
 
   test('array mutation', function(assert) {
-    const env = new Environment({ foo: ['bar', 'baz'] });
-    const foo = get(env, 'foo');
-    assert.equal(get(foo, 1), 'baz');
-    set(foo, 1, 'oops');
-    assert.equal(get(foo, 1), 'oops');
+    const foo = ['bar', 'baz'];
+    const env = new Environment({ foo });
+    set(env, 'foo.1', 'oops');
+    assert.equal(foo[1], 'oops');
     assert.equal(get(env, 'foo.1'), 'oops');
+    set(env, 'foo.0', 'oops again');
+    assert.equal(get(foo, 'firstObject'), 'oops again');
   });
 
   test('HTML-safe strings', function(assert) {

--- a/tests/unit/environment-test.js
+++ b/tests/unit/environment-test.js
@@ -24,8 +24,19 @@ module('Unit | environment', function() {
     const env = new Environment({ foo: ['bar'] });
     set(env, 'baz', 'bax');
     assert.equal(get(env, 'baz'), 'bax');
+    assert.equal(get(env, 'foo.length'), 1);
     set(env, 'foo.3', 'qux');
     assert.equal(get(env, 'foo.3'), 'qux');
+    assert.equal(get(env, 'foo.length'), 4);
+  });
+
+  test('array mutation', function(assert) {
+    const env = new Environment({ foo: ['bar', 'baz'] });
+    const foo = get(env, 'foo');
+    assert.equal(get(foo, 1), 'baz');
+    set(foo, 1, 'oops');
+    assert.equal(get(foo, 1), 'oops');
+    assert.equal(get(env, 'foo.1'), 'oops');
   });
 
   test('HTML-safe strings', function(assert) {


### PR DESCRIPTION
This PR changes how unknown properties are get and set on `EnvironmentArray`s. With this change it is now possible to get/set array indices on arrays in the environment, whereas previously you needed to replace the array in place with the new values.