### PR TITLE
depend on botanist directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-exclaim",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "An addon allowing apps to expose declarative, JSON-configurable custom UIs backed by Ember components",
   "keywords": [
     "ember-addon"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "ember-botanist": "^1.0.1",
+    "botanist": "^1.3.0",
     "ember-cli-babel": "^7.26.3",
     "ember-cli-htmlbars": "^5.7.1"
   },

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "botanist": "^1.3.0",
+    "ember-auto-import": "^1.12.0",
     "ember-cli-babel": "^7.26.3",
     "ember-cli-htmlbars": "^5.7.1"
   },
@@ -39,7 +40,6 @@
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-ace": "^1.3.1",
-    "ember-auto-import": "^1.11.2",
     "ember-cli": "~3.26.1",
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-dependency-lint": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4801,10 +4801,10 @@ ember-ace@^1.3.1:
     ember-cli-htmlbars "^2.0.2"
     ember-cli-node-assets "^0.2.2"
 
-ember-auto-import@^1.10.1, ember-auto-import@^1.11.2:
-  version "1.11.3"
-  resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-1.11.3.tgz#6e3384a7fbb163384a34546f2e902cd297b0e683"
-  integrity sha512-ekq/XCvsonESobFU30zjZ0I4XMy2E/2ZILCYWuQ1JdhcCSTYhnXDZcqRW8itUG7kbsPqAHT/XZ1LEZYm3seVwQ==
+ember-auto-import@^1.10.1, ember-auto-import@^1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-1.12.0.tgz#52246b04891090e2608244e65c4c6af7710df12b"
+  integrity sha512-fzMGnyHGfUNFHchpLbJ98Vs/c5H2wZBMR9r/XwW+WOWPisZDGLUPPyhJQsSREPoUQ+o8GvyLaD/rkrKqW8bmgw==
   dependencies:
     "@babel/core" "^7.1.6"
     "@babel/preset-env" "^7.10.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2876,7 +2876,7 @@ bops@0.0.3:
     base64-js "0.0.2"
     to-utf8 "0.0.1"
 
-botanist@^1.2.0:
+botanist@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/botanist/-/botanist-1.3.0.tgz#1184893efc621f64408ec7188d9668f82fb8be15"
   integrity sha1-EYSJPvxiH2RAjscYjZZo+C+4vhU=
@@ -4835,14 +4835,6 @@ ember-auto-import@^1.10.1, ember-auto-import@^1.11.2:
     typescript-memoize "^1.0.0-alpha.3"
     walk-sync "^0.3.3"
     webpack "^4.43.0"
-
-ember-botanist@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/ember-botanist/-/ember-botanist-1.0.1.tgz#de6281d83c34cb9d7606817794849f1b6c128ec2"
-  integrity sha1-3mKB2Dw0y512BoF3lISfG2wSjsI=
-  dependencies:
-    botanist "^1.2.0"
-    ember-cli-node-assets "^0.2.2"
 
 ember-cli-babel-plugin-helpers@^1.0.0, ember-cli-babel-plugin-helpers@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
We don't need `ember-botanist` anymore because ember-auto-import allows us to use botanist directly.