### PR TITLE
Expose `ComponentSpec` and `HelperSpec` as public imports

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,1 +1,3 @@
 export { wrap, unwrap } from 'ember-exclaim/-private/environment';
+export { default as ComponentSpec } from 'ember-exclaim/-private/component-spec';
+export { default as HelperSpec } from 'ember-exclaim/-private/helper-spec';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-exclaim",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "An addon allowing apps to expose declarative, JSON-configurable custom UIs backed by Ember components",
   "keywords": [
     "ember-addon"

--- a/tests/unit/build-spec-processor-test.js
+++ b/tests/unit/build-spec-processor-test.js
@@ -1,8 +1,7 @@
 import { module, test } from 'qunit';
 import buildSpecProcessor from 'ember-exclaim/-private/build-spec-processor';
 import Binding from 'ember-exclaim/-private/binding';
-import ComponentSpec from 'ember-exclaim/-private/component-spec';
-import HelperSpec from 'ember-exclaim/-private/helper-spec';
+import { ComponentSpec, HelperSpec } from 'ember-exclaim';
 
 module('Unit | build-spec-processor', function () {
   test('processing valid config', function (assert) {

--- a/tests/unit/helper-spec-test.js
+++ b/tests/unit/helper-spec-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import Binding from 'ember-exclaim/-private/binding';
-import HelperSpec from 'ember-exclaim/-private/helper-spec';
+import { HelperSpec } from 'ember-exclaim';
 
 module('Unit | helper-spec');
 


### PR DESCRIPTION
This should make migrating from v1 to v2 a bit easier when we release it (since Rollup is going to eliminate all those `-private` paths)