### PR TITLE
Use `dependentKeyCompat` for bindings

### DIFF
--- a/ember-exclaim/package.json
+++ b/ember-exclaim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-exclaim",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "An addon allowing apps to expose declarative, JSON-configurable custom UIs backed by Ember components",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
## Background

Components in a shared library of Exclaim implementations can't know up front whether they're going to be operating in an `ExclaimUi` with `@useClassicReactivity` set or not. While it's possible to just cut a breaking release of such libraries and assumed Octane reactivity, that doesn't provide a very nice migration path.

## This Change

By applying `dependentKeyCompat` to the property descriptors we set up for `$bind`s in the modern env, we make it so that they can safely be targeted as `@computed` dependencies. This means shared component libraries can safely use `@computed` as a lowest common denominator as their consumers slowly migrate away from classic reactivity, then switch to native getters and stop using `@computed` in a breaking release later on.