### PR TITLE
Fix template-registry import

### DIFF
--- a/ember-exclaim/declarations/template-registry.d.ts
+++ b/ember-exclaim/declarations/template-registry.d.ts
@@ -1,4 +1,4 @@
-import { ExclaimUi } from './components/exclaim-ui';
+import ExclaimUi from './components/exclaim-ui';
 
 export default interface ExclaimTemplateRegistry {
   ExclaimUi: typeof ExclaimUi;

--- a/ember-exclaim/package.json
+++ b/ember-exclaim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-exclaim",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "An addon allowing apps to expose declarative, JSON-configurable custom UIs backed by Ember components",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
The real fix here is to ultimately generate these declarations from source rather than hand-write them, but in the interest of moving forward, I'm just going to release this as a bugfix and we can return to do a proper conversion in the future.